### PR TITLE
[fix(timescaledb)] 환경설정 & 문서 수정

### DIFF
--- a/timescaledb/docker-compose.timescale.yml
+++ b/timescaledb/docker-compose.timescale.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - timescale_data:/var/lib/postgresql/data
     restart: unless-stopped

--- a/timescaledb/init_timescale_test.sql
+++ b/timescaledb/init_timescale_test.sql
@@ -2,9 +2,9 @@
 -- TimescaleDB quick test script for manual use
 -- Usage (example):
 -- 1) Using docker exec into your container:
---   docker exec -i panopticon-timescaledb psql -U admin -d panopticon -f /dev/stdin < init_timescale_test.sql
+--   docker exec -i <컨테이너 이름> psql -U admin -d panopticon -f /dev/stdin < init_timescale_test.sql
 -- 2) Or from host with psql (if PGPASSWORD set):
---  PGPASSWORD=admin123 psql -h localhost -p 5432 -U admin -d panopticon -f init_timescale_test.sql
+--  PGPASSWORD=admin123 psql -h localhost -p 5433 -U admin -d panopticon -f init_timescale_test.sql
 --
 -- This file is idempotent: it uses IF NOT EXISTS where appropriate.
 


### PR DESCRIPTION
PostgreSQL의 5432번 포트와 TimescaleDB의 5432번 포트가 충돌이 발생해서, TimescaleDB의 호스트 포트 번호를 5433번으로 수정했습니다.